### PR TITLE
fix: empty space

### DIFF
--- a/index.js
+++ b/index.js
@@ -134,7 +134,7 @@ class Chalk {
         const bgColor = inverse ? fg : bg;
         const fgColor = inverse ? bg : fg;
 
-        const output = (wrap ? '<span style="' : '') +
+        const output = (wrap ? '<span style="white-space: pre;' : '') +
         (bgColor ? 'background-color:' + bgColor + ';' : '') +
         (fgColor ? 'color:' + fgColor + ';' : '') +
         (dim ? 'opacity:0.5;' : '') +


### PR DESCRIPTION
Hi Henry! 

I found a small issue here. If the text to render is just an empty space, it is not visualized.

So far, I've found a fix that works well for me in another implementation that I made, just copying `chalk-dom` and traducing it to Spanish.

Here is the reproduction link: 

https://playcode.io/1530673

As you can see, `chalk-dom` doesn't renderize the blue background, but `tiza` does renderize the red background. Althought it works well for two spaces.

Thanks!